### PR TITLE
Create hidden empty file so destination path is always created as dir…

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ services:
 
 # Gotchas
 
-- When only a single file is to be uploaded, the destination directory must exist otherwise the backup file will be
-  named as the destination (scp limitation)
 - Backups of removed databases remain on the remote SFTP server (not locally). Not fixable using scp only.
 
 # Todos

--- a/include/utils.sh
+++ b/include/utils.sh
@@ -19,5 +19,8 @@ upload_backup() {
   print_msg "Copying backup size `du -bhs $DIR_BACKUP/ | awk '{print $1}'` to SFTP $SFTP"
   rm $DIR_UPLOADED/* 2>/dev/null
   mkdir -p ~/.ssh && ssh-keyscan -H $SFTP_HOST 2> /dev/null > $HOME/.ssh/known_hosts
-  sshpass -e scp -p $DIR_BACKUP/* $SFTP && mv $DIR_BACKUP/* $DIR_UPLOADED/ || print_error "[ERR] Error copying to SFTP server"
+  # Create an empty file to make sure there are at least two backup files. This means that the backup will be uploaded
+  # to the SFTP path created as a new directory instead of renaming the single file to that path as a file.
+  touch $DIR_BACKUP/.keep
+  sshpass -e scp -p $DIR_BACKUP/.keep $DIR_BACKUP/* $SFTP && mv $DIR_BACKUP/* $DIR_UPLOADED/ || print_error "[ERR] Error copying to SFTP server"
 }


### PR DESCRIPTION
…ectory instead of renaming single file to backup to the destination path