### PR TITLE
Bump dockerize version to v0.8.0, update debian base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mcuadros/ofelia:v3.0.8 AS ofelia
 
 FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
-ARG DOCKERIZE_VERSION=v0.7.0
+ARG DOCKERIZE_VERSION=v0.8.0
 ARG POSTGRES_CLIENT_VERSION=15
 
 LABEL authors="matthijsln & o.porsius"


### PR DESCRIPTION
This provides some security updates in the Go stack as well as any updates in the base image up to 20240812.

see: 
- https://github.com/jwilder/dockerize/releases/tag/v0.8.0
- https://github.com/debuerreotype/docker-debian-artifacts/commit/39095b9bf8cbb2635be1e2dfed3d152f0b3d72bf